### PR TITLE
#70 Fix error message displaying when refreshing page after logout

### DIFF
--- a/GonqBox/src/gonqbox/servlets/LogoutServlet.java
+++ b/GonqBox/src/gonqbox/servlets/LogoutServlet.java
@@ -25,7 +25,12 @@ public class LogoutServlet extends HttpServlet{
 		if(request.getSession().getAttribute("user") != null){
 			request.getSession().setAttribute("user", null);
 			request.setAttribute("index_messenger",bundle.getObject("logoutSuccess"));
-		}else{
+		}
+		else if(request.getSession().getAttribute("user") == null){
+			//user refreshed page so dialogue still appears 
+			request.getSession().setAttribute("user", null);
+		}
+		else{
         	request.setAttribute("index_messenger_err",bundle.getObject("logoutUnsuccessful"));
 		}        
     	request.getRequestDispatcher(Pages.INDEX.toString()).forward(request,response);


### PR DESCRIPTION
Made it so that error message no longer displays when user refreshes page or the language is changed. 
Note: To do this I changed the way logout errors are handled, this may result in logout error messages not displaying.